### PR TITLE
fix: don't exit on unset variables

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -13,5 +13,5 @@ fi
 cmd="${cmd} ${releases_path}"
 
 # Fetch all tag names, except 'latest_release'.
-# Also ripping off the 'v' prefix as it causes issues with 'asdf install foo latest'
+# Also ripping off the 'v' prefix as it causes issues with 'asdf install foo latest'.
 echo $(eval "$cmd" | grep -oE "tag_name\": \".{1,15}\"," | grep -v latest_release | sed 's/tag_name\": \"//; s/\",//; s/^v//; s/",//' | sort_versions)

--- a/bin/list-all
+++ b/bin/list-all
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -eo pipefail
 
 # shellcheck source=../lib/utils.sh
 source "$(dirname "$0")/../lib/utils.sh"


### PR DESCRIPTION
In our case, `GITHUB_API_TOKEN` isn't set, so `list-all` fails. Changing to `set -eo` so it won't exit on unset variables.